### PR TITLE
Allow Pip Installs and Copy Minion Config

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -75,8 +75,9 @@ Vagrant.configure(2) do |config|
   # Main vm provisioning via salt
   config.vm.provision :salt do |salt|
 
+    salt.bootstrap_options = "-P -c /tmp" # Vagrant issue #6029 and #5973
     salt.install_master = false
-    install_type = "stable"
+    salt.install_type = "stable"
     salt.minion_config = "salt/minion"
     salt.run_highstate = true
     salt.colorize = true


### PR DESCRIPTION
Fixes is210-faculty/development-environment#1 by adding a bootstrap option (-P) to allow Pip installs after recent changes to Salt's bootstrapping produced an error (see mitchellh/vagrant#6029). Also adds "-c /tmp" to copy over the minion config since Vagrant versions 1.7.3-4 fail to copy the config and produce the following error (see mitchellh/vagrant#5973):

```
Failed to upload a file to the guest VM via SCP due to a permissions error.
This is normally because the SSH user doesn't have permission to write to
the destination location. Alternately, the user running Vagrant on the host
machine may not have permission to read the file.

Source: /home/jwokaty/Class/is210/development-environment/salt/minion
Dest: /etc/salt/minion
```

@cheuschober Can you check if you have any problems trying to vagrant up with this commit? Let me know if you want me to merge the request.
